### PR TITLE
disable normal defaults when "Import Normals" is not used

### DIFF
--- a/Files/BCH/BchModelImporter.cs
+++ b/Files/BCH/BchModelImporter.cs
@@ -759,7 +759,7 @@ namespace CtrLibrary.Bch
                 Scale = settings.Position.Scale,
             });
             //Vertex normals
-            if (meshes.Any(x => x.HasNormals))
+            if (settings.ImportNormals && meshes.Any(x => x.HasNormals))
             {
                 attributes.Add(new PICAAttribute()
                 {

--- a/Files/BCRES/BcresModelImporter.cs
+++ b/Files/BCRES/BcresModelImporter.cs
@@ -393,7 +393,7 @@ namespace CtrLibrary.Bcres
             CalculateBounding(ref gfxShape, iomesh);
 
             //Create a default normal set if one is not present
-            if (!vertexBuffer.Attributes.Any(x => x.AttrName == PICAAttributeName.Normal))
+            if (settings.ImportNormals && !vertexBuffer.Attributes.Any(x => x.AttrName == PICAAttributeName.Normal))
             {
                 //Constant normal if not present
                 float[] normal = new float[3] { 1, 0, 0 };


### PR DESCRIPTION
These changes should remove normals from PICA attributes menu when the option is deselected; it should also remove normals from the CGFX shape. Normals still appear under the Vertex Data tab.

<img width="518" height="637" alt="image" src="https://github.com/user-attachments/assets/171099da-3b16-451c-9c80-59de3efbfea2" />
<img width="528" height="318" alt="image" src="https://github.com/user-attachments/assets/18e57010-b676-4dd8-b574-85e2cff37290" />
